### PR TITLE
Narrow gitignore rule for binary output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ bin/
 *.test
 
 # Output of go build
-whisper-tray
+/whisper-tray
+/whisper-tray.exe
 *.app
 
 # Go workspace file


### PR DESCRIPTION
## Summary
- scope binary ignore to repo root so cmd/whisper-tray remains tracked

## Testing
- not run
